### PR TITLE
교육 결과물 페이지 GitHub 리포지터리 주소 삭제

### DIFF
--- a/edureports/2016_cau_summer.html
+++ b/edureports/2016_cau_summer.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_dgu_fall.html
+++ b/edureports/2016_dgu_fall.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_hyu_fall.html
+++ b/edureports/2016_hyu_fall.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_ku_winter.html
+++ b/edureports/2016_ku_winter.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_snu_fall.html
+++ b/edureports/2016_snu_fall.html
@@ -220,10 +220,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -249,10 +246,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -281,10 +275,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_snu_spring.html
+++ b/edureports/2016_snu_spring.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2016_ysu_fall.html
+++ b/edureports/2016_ysu_fall.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_cau_summer.html
+++ b/edureports/2017_cau_summer.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_cau_winter.html
+++ b/edureports/2017_cau_winter.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_hyu_spring.html
+++ b/edureports/2017_hyu_spring.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_ku_summer.html
+++ b/edureports/2017_ku_summer.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_ku_winter.html
+++ b/edureports/2017_ku_winter.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_snu_fall.html
+++ b/edureports/2017_snu_fall.html
@@ -216,10 +216,7 @@
              <h4>발표 영상</h4><br />
              <iframe width="560" height="315" src="https://www.youtube.com/embed/rSjonWGdGds?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
              <div>
-               <a href="https://github.com/ProjectInTheClass/DayFeel/">
-                 <img src="../assets/img/github.png" class="gotoapp" />
-               </a>
-               <a href="https://github.com/ProjectInTheClass/DayFeel/">
+               <a href="https://projectintheclass.github.io/DayFeel/">
                  <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
                </a>
              </div>
@@ -248,9 +245,6 @@
          <h4 class="margin-none">발표 영상</h4><br />
          <iframe width="560" height="315" src="https://www.youtube.com/embed/I6CZmlK7HKQ?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
          <div>
-           <a href="https://github.com/ProjectInTheClass/SoundDiary/" target="_blank">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
            <a href="https://projectintheclass.github.io/SoundDiary/" target="_blank">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
@@ -280,10 +274,6 @@
            <h4 class="margin-none">발표 영상</h4><br />
            <iframe width="560" height="315" src="https://www.youtube.com/embed/TjDmxS5vlSE?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
            <div>
-
-             <a href="https://github.com/ProjectInTheClass/StudyBookPlanner" target="_blank">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
              <a href="https://projectintheclass.github.io/StudyBookPlanner" target="_blank">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
@@ -313,10 +303,7 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/Lme-NoNZcEo?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Vacancy/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
-          <a href="https://github.com/ProjectInTheClass/Vacancy/" target="_blank">
+          <a href="https://projectintheclass.github.io/Vacancy/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
         </div>
@@ -347,9 +334,6 @@
          <h4 class="margin-none">발표 영상</h4><br />
          <iframe width="560" height="315" src="https://www.youtube.com/embed/k9gIWSpaF88?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
          <div>
-           <a href="https://github.com/ProjectInTheClass/HEY/" target="_blank">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
            <a href="https://projectintheclass.github.io/HEY/" target="_blank">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
@@ -379,9 +363,6 @@
     <h4 class="margin-none">발표 영상</h4><br />
     <iframe width="560" height="315" src="https://www.youtube.com/embed/4Y8wFzxHduk?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
     <div>
-      <a href="https://github.com/ProjectInTheClass/NaggingScheduler" target="_blank">
-        <img src="../assets/img/github.png" class="gotoapp" />
-      </a>
       <a href="https://projectintheclass.github.io/NaggingScheduler" target="_blank">
         <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
       </a>
@@ -413,9 +394,6 @@
      <h4 class="margin-none">발표 영상</h4><br />
      <iframe width="560" height="315" src="https://www.youtube.com/embed/PGSmNc3Ei9c?list=PLBjx8AiS7qA2rLOY-2q4-Cthq8NvW3HyZ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
      <div>
-       <a href="https://github.com/ProjectInTheClass/Shanoti" target="_blank">
-         <img src="../assets/img/github.png" class="gotoapp" />
-       </a>
        <a href="https://projectintheclass.github.io/Shanoti" target="_blank">
          <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
        </a>

--- a/edureports/2017_snu_spring.html
+++ b/edureports/2017_snu_spring.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2017_ysu_spring.html
+++ b/edureports/2017_ysu_spring.html
@@ -243,10 +243,7 @@
              <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
-             <a href="https://github.com/ProjectInTheClass/Mouda">
+             <a href="https://projectintheclass.github.io/Mouda/">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
            </div>
@@ -272,10 +269,7 @@
             <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda">
+            <a href="https://projectintheclass.github.io/Mouda/">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -304,10 +298,7 @@
            <a href="https://itunes.apple.com/kr/app/1%EC%9B%94-1%EC%9D%BC-%EB%AA%A9%ED%91%9C-%EA%B4%80%EB%A6%AC-%EC%96%B4%ED%94%8C%EB%A6%AC%EC%BC%80%EC%9D%B4%EC%85%98/id1218696438?mt=8">
  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
            </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
-             <img src="../assets/img/github.png" class="gotoapp" />
-           </a>
-           <a href="https://github.com/ProjectInTheClass/Mouda">
+           <a href="https://projectintheclass.github.io/Mouda/">
              <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
            </a>
          </div>

--- a/edureports/2018_cau_summer.html
+++ b/edureports/2018_cau_summer.html
@@ -228,9 +228,6 @@
           ">
          <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a>
-          <a href="https://github.com/ProjectInTheClass/Sulchedule" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Sulchedule/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -260,9 +257,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/epHsZa06WGo" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/AlbaGo" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/AlbaGo/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -292,9 +286,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/cX6GtOAQJ2g" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/GGuk" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/GGuk/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -324,10 +315,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/iKUJfSrh6vI" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/nBreadBakeryProject" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/nBreadBakeryProject/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -355,9 +342,6 @@
           <h4 class="margin-none">발표 영상</h4><br />
           <iframe width="560" height="315" src="https://www.youtube.com/embed/a2vNYJk9kbM" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
           <div>
-            <a href="https://github.com/ProjectInTheClass/ForDreamer" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
             <a href="https://projectintheclass.github.io/ForDreamer/" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
@@ -390,9 +374,6 @@
           <!-- <a href="https://itunes.apple.com/us/app/%ED%95%84%EB%A7%81%ED%83%80%EC%9E%84/id1350330770?mt=8" target="_blank">
          <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a> -->
-          <a href="https://github.com/ProjectInTheClass/Armgi/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Armgi/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -425,9 +406,6 @@
           <!-- <a href="https://itunes.apple.com/us/app/%EB%8F%84%EB%A6%AC%EB%8B%88%ED%8B%B0/id1350340428?mt=8" target="">
          <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a> -->
-          <a href=" https://github.com/ProjectInTheClass/Noty" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Noty/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -457,9 +435,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/b7jOUbAwLug" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Aplus" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Aplus/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -492,9 +467,6 @@
           <a href="https://itunes.apple.com/kr/app/%EC%A7%91%EC%A4%91/id1431676325?mt=8" target="
           ">
          <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
-          </a>
-          <a href="https://github.com/cauios/cau_study_by_cauios" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
           </a>
           <a href="https://cauios.github.io/cau_study_by_cauios/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>

--- a/edureports/2018_cau_winter.html
+++ b/edureports/2018_cau_winter.html
@@ -231,9 +231,6 @@
             <h4 class="margin-none">발표 영상</h4><br />
             <iframe width="560" height="315" src="https://www.youtube.com/embed/Udt5JecZF9o"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
             <div>
-              <a href=" https://github.com/ProjectInTheClass/chongmuda" target="_blank">
-                <img src="../assets/img/github.png" class="gotoapp" />
-              </a>
               <a href="https://projectintheclass.github.io/chongmuda/" target="_blank">
                 <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
               </a>
@@ -264,9 +261,6 @@
            <h4 class="margin-none">발표 영상</h4><br />
            <iframe width="560" height="315" src="https://www.youtube.com/embed/b8HopTvKU_E" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
            <div>
-             <a href="https://github.com/ProjectInTheClass/ForYou" target="_blank">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
              <a href="https://projectintheclass.github.io/ForYou/" target="_blank">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
@@ -298,10 +292,6 @@
              <h4 class="margin-none">발표 영상</h4><br />
              <iframe width="560" height="315" src="https://www.youtube.com/embed/MNOXz3Lmy0g" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
              <div>
-
-               <a href="https://github.com/ProjectInTheClass/OURSNAPS" target="_blank">
-                 <img src="../assets/img/github.png" class="gotoapp" />
-               </a>
                <a href="https://projectintheclass.github.io/OURSNAPS/" target="_blank">
                  <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
                </a>
@@ -333,10 +323,7 @@
             ">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/Mouda" target="_blank">
+            <a href="https://projectintheclass.github.io/Mouda/" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
           </div>
@@ -368,9 +355,6 @@
            <h4 class="margin-none">발표 영상</h4><br />
            <iframe width="560" height="315" src="https://www.youtube.com/embed/HTLU-XUCZIg?list=PLBjx8AiS7qA3Pn8YOT6gojXrHG3hXTGoI" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
            <div>
-             <a href="https://github.com/ProjectInTheClass/TeamWork2018/" target="_blank">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
              <a href="https://projectintheclass.github.io/TeamWork2018/" target="_blank">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
@@ -401,9 +385,6 @@
       <h4 class="margin-none">발표 영상</h4><br />
       <iframe width="560" height="315" src="https://www.youtube.com/embed/OG6i7-KDB44" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
       <div>
-        <a href="https://github.com/ProjectInTheClass/bestbefore" target="_blank">
-          <img src="../assets/img/github.png" class="gotoapp" />
-        </a>
         <a href="https://projectintheclass.github.io/bestbefore/" target="_blank">
           <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
         </a>
@@ -435,9 +416,6 @@
        <div>
          <a href="https://itunes.apple.com/kr/app/%EC%A4%91%EC%95%99%EB%8C%80%EA%B8%B0%EC%88%99%EC%82%AC%EC%95%8C%EB%A6%AC%EB%AF%B8/id1363880842?mt=8" target="_blank">
            <img src="../assets/img/apple-store.png" class="gotoapp" style="padding: 5px 20px;" />
-         </a>
-         <a href="https://github.com/ProjectInTheClass/CAUDormitory" target="_blank">
-           <img src="../assets/img/github.png" class="gotoapp" />
          </a>
          <a href="https://projectintheclass.github.io/CAUDormitory/" target="_blank">
            <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>

--- a/edureports/2018_dgu_winter.html
+++ b/edureports/2018_dgu_winter.html
@@ -219,9 +219,6 @@ ss<!DOCTYPE html>
         <a href="https://itunes.apple.com/us/app/%EC%9B%90%EC%83%B7%ED%86%A1/id1350334218?mt=8" target="_blank">
           <img src="../assets/img/apple-store.png" class="gotoapp" style="padding: 5px 20px;" />
         </a>
-        <a href="https://github.com/ProjectInTheClass/OneshotTalk" target="_blank">
-          <img src="../assets/img/github.png" class="gotoapp" />
-        </a>
         <a href="https://projectintheclass.github.io/OneshotTalk/" target="_blank">
           <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
         </a>
@@ -254,9 +251,6 @@ ss<!DOCTYPE html>
        <div>
          <a href="https://itunes.apple.com/us/app/%ED%95%84%EB%A7%81%ED%83%80%EC%9E%84/id1350330770?mt=8" target="_blank">
            <img src="../assets/img/apple-store.png" class="gotoapp" style="padding: 5px 20px;" />
-         </a>
-         <a href="https://github.com/ProjectInTheClass/PillingTime/" target="_blank">
-           <img src="../assets/img/github.png" class="gotoapp" />
          </a>
          <a href="https://projectintheclass.github.io/PillingTime/" target="_blank">
            <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
@@ -291,9 +285,6 @@ ss<!DOCTYPE html>
              <a href="https://itunes.apple.com/us/app/%EB%8F%84%EB%A6%AC%EB%8B%88%ED%8B%B0/id1350340428?mt=8" target="">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
              </a>
-             <a href=" https://github.com/ProjectInTheClass/dorinity" target="_blank">
-               <img src="../assets/img/github.png" class="gotoapp" />
-             </a>
              <a href="https://projectintheclass.github.io/dorinity/" target="_blank">
                <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
              </a>
@@ -323,9 +314,6 @@ ss<!DOCTYPE html>
           <h4 class="margin-none">발표 영상</h4><br />
           <iframe width="560" height="315" src="https://www.youtube.com/embed/IVPQwdd2_tI" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
           <div>
-            <a href="https://github.com/ProjectInTheClass/MJARProject" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
             <a href="https://projectintheclass.github.io/MJARProject/" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
@@ -359,9 +347,6 @@ ss<!DOCTYPE html>
        <h4 class="margin-none">발표 영상</h4><br />
        <iframe width="560" height="315" src="https://www.youtube.com/embed/81qy6hpiwQY" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
        <div>
-         <a href="https://github.com/ProjectInTheClass/Sporting" target="_blank">
-           <img src="../assets/img/github.png" class="gotoapp" />
-         </a>
          <a href="https://projectintheclass.github.io/Sporting/" target="_blank">
            <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
          </a>
@@ -391,10 +376,6 @@ ss<!DOCTYPE html>
        <h4 class="margin-none">발표 영상</h4><br />
        <iframe width="560" height="315" src="https://www.youtube.com/embed/TSIv-5x660w" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
        <div>
-
-         <a href="https://github.com/ProjectInTheClass/AppleMarket" target="_blank">
-           <img src="../assets/img/github.png" class="gotoapp" />
-         </a>
          <a href="https://projectintheclass.github.io/AppleMarket/" target="_blank">
            <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
          </a>

--- a/edureports/2018_hyu_spring.html
+++ b/edureports/2018_hyu_spring.html
@@ -213,10 +213,6 @@
       <h4 class="margin-none">발표 영상</h4><br />
       <iframe width="560" height="315" src="https://www.youtube.com/embed/xwcb-scJK5I?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
       <div>
-
-        <a href="https://github.com/ProjectInTheClass/UZuCha" target="_blank">
-          <img src="../assets/img/github.png" class="gotoapp" />
-        </a>
         <a href="https://projectintheclass.github.io/UZuCha" target="_blank">
           <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
         </a>
@@ -245,12 +241,8 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/pk0O_N8N388?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://itunes.apple.com/us/app/smarthanyang/id1420489675?ls=1&mt=8" target="
-          ">
-<img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
-          </a>
-          <a href="https://github.com/ProjectInTheClass/SmartHanyang" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
+          <a href="https://itunes.apple.com/us/app/smarthanyang/id1420489675?ls=1&mt=8" target="">
+            <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a>
           <a href="https://projectintheclass.github.io/SmartHanyang" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
@@ -285,9 +277,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/jBxZ9qB0ZTY?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/GSBN" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/GSBN" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -318,9 +307,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/hs_fcZ5AIx8?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/CLUBB" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/CLUBB/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -349,9 +335,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/jKc2ZALcU6E?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/MapDiary" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/MapDiary" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -383,9 +366,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/pgMRwhiBDZs?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Moment" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Moment" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -414,9 +394,6 @@
           <h4 class="margin-none">발표 영상</h4><br />
           <iframe width="560" height="315" src="https://www.youtube.com/embed/g_a8wfFSQyE?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
           <div>
-            <a href="https://github.com/ProjectInTheClass/DolphinBook" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
             <a href="https://projectintheclass.github.io/DolphinBook/" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
@@ -447,12 +424,8 @@
           <h4 class="margin-none">발표 영상</h4><br />
           <iframe width="560" height="315" src="https://www.youtube.com/embed/AKyS17yLipU?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
           <div>
-            <a href="https://itunes.apple.com/us/app/wishlisthy/id1420501007?ls=1&mt=8" target="
-            ">
-  <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
-            <a href="https://github.com/ProjectInTheClass/Wish_List" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
+            <a href="https://itunes.apple.com/us/app/wishlisthy/id1420501007?ls=1&mt=8" target="">
+              <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             <a href="https://projectintheclass.github.io/Wish_List" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
@@ -484,9 +457,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/4s-nH3PNSyY?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-        <a href="https://github.com/ProjectInTheClass/Honbabhanyang" target="_blank">
-          <img src="../assets/img/github.png" class="gotoapp" />
-        </a>
         <a href="https://projectintheclass.github.io/Honbabhanyang" target="_blank">
           <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
         </a>
@@ -517,9 +487,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/VdOB_V0ksRE?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Glass" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Glass" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -553,9 +520,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/pgMRwhiBDZs?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Emogi" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Emogi" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -583,9 +547,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/MKYetiJr818?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/TriPlanner_" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           </div>
       </div>
     </div><!-- row -->
@@ -614,9 +575,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/oibZ1aAWS_I?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/CLEAN_MANAGER" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/CLEAN_MANAGER" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -644,9 +602,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/9_5UdSv0x8k?list=PLBjx8AiS7qA0rtzpNCfKu_e54Kmd-A50D" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/TwithS" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/TwithS" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>

--- a/edureports/2018_ku_summer.html
+++ b/edureports/2018_ku_summer.html
@@ -214,9 +214,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/VbHmA73KhJQ" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/NChan" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/NChan/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -249,9 +246,6 @@
             <!-- <a href="https://itunes.apple.com/us/app/%EB%8F%84%EB%A6%AC%EB%8B%88%ED%8B%B0/id1350340428?mt=8" target="">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a> -->
-          <a href=" https://github.com/ProjectInTheClass/GGULUE" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/GGULUE/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -280,9 +274,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/mmTzFwPRz48" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/BasketMatch" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/BasketMatch/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -313,10 +304,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/LlSi74zIVwA" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/Busking" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Busking/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -346,9 +333,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/l6OBxxDvq8U" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/School1" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/School1/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -378,10 +362,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/u5OFEGU8W7Q" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/Calorie_Calculator" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Calorie_Calculator/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -410,9 +390,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/iCSlTDGO_kA" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/HumptyDumpty" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/HumptyDumpty/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -442,10 +419,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/xUNDM0zv03E" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/travelAlone" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://dongl1.wixsite.com/dongl" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -477,9 +450,6 @@
           <!-- <a href="https://itunes.apple.com/us/app/%ED%95%84%EB%A7%81%ED%83%80%EC%9E%84/id1350330770?mt=8" target="_blank">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a> -->
-          <a href="https://github.com/ProjectInTheClass/kkukkuccacca/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/kkukkuccacca/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -509,9 +479,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/VX2AEDYwL38" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/HealthKeeper" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/HealthKeeper/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -543,9 +510,6 @@
           <!-- <a href="https://itunes.apple.com/us/app/%EC%9B%90%EC%83%B7%ED%86%A1/id1350334218?mt=8" target="_blank">
 <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
           </a> -->
-          <a href="https://github.com/ProjectInTheClass/gonggeum/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/gonggeum//" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -575,10 +539,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/LNQRPL9lIKI" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/MOMENT-Diary" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/MOMENT-Diary/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>

--- a/edureports/2018_ku_winter.html
+++ b/edureports/2018_ku_winter.html
@@ -215,9 +215,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/vvakY1WjmM4?list=PLBjx8AiS7qA3Jw9c736zvT4t7dL43zpFu"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/GAZZA/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://kawai6214.wixsite.com/GAZZA/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -246,9 +243,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/bPU-FZ7ukpM" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Lecture_Record/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Lecture_Record/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -277,9 +271,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/fPGflvPKo0w" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/KUnet" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/KUnet" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -313,9 +304,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/t_uXl9q_Z8o"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/5MBUS" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://kawai6214.wixsite.com/5minutes" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -344,9 +332,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/DVR8_ijsMgw" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/Sharing-Clothes/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/Sharing-Clothes" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -378,10 +363,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/duad_W0o3t0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-
-          <a href="https://github.com/ProjectInTheClass/QandA" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/QandA" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -410,9 +391,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/ohaguY3t1PM" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/TODAY" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/TODAY" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -441,9 +419,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/fJUfvpZ6E6Q" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/OSORI/" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/OSORI/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>
@@ -477,9 +452,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/KxR66PxJP_c" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/OOH" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/OOH" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>

--- a/edureports/2018_swu_summer.html
+++ b/edureports/2018_swu_summer.html
@@ -214,9 +214,6 @@
             <h4 class="margin-none">발표 영상</h4><br />
             <iframe width="560" height="315" src="https://www.youtube.com/embed/0qDu2X_l6W0" frameborder="0" gesture="media" allow="encrypted-media" allowfullscreen="" style="margin-bottom:20px;"></iframe>
             <div>
-              <a href="https://github.com/ProjectInTheClass/moongaemoongae/" target="_blank">
-                <img src="../assets/img/github.png" class="gotoapp" />
-              </a>
               <a href="https://projectintheclass.github.io/moongaemoongae/" target="_blank">
                 <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
               </a>
@@ -248,9 +245,6 @@
           <div>
             <a href="https://itunes.apple.com/kr/app/id1423018646">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
-            </a>
-            <a href="https://github.com/ProjectInTheClass/SaveDonDon" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
             </a>
             <a href="https://projectintheclass.github.io/SaveDonDon" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
@@ -284,9 +278,6 @@
             <a href="https://itunes.apple.com/kr/app/%EC%9E%AC%EA%B3%A0%EC%9E%AC%EA%B3%A0/id1423132116?mt=8">
   <img src="../assets/img/app-store.png" class="" style="padding: 5px 0.5px; height: 48px;" />
             </a>
-            <a href="https://github.com/ProjectInTheClass/JaegoJaego" target="_blank">
-              <img src="../assets/img/github.png" class="gotoapp" />
-            </a>
             <a href="https://projectintheclass.github.io/JaegoJaego" target="_blank">
               <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
             </a>
@@ -315,9 +306,6 @@
         <h4 class="margin-none">발표 영상</h4><br />
         <iframe width="560" height="315" src="https://www.youtube.com/embed/lK391FiKQ4w"  style="margin-bottom:20px;" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen ></iframe>
         <div>
-          <a href="https://github.com/ProjectInTheClass/EnglishBook" target="_blank">
-            <img src="../assets/img/github.png" class="gotoapp" />
-          </a>
           <a href="https://projectintheclass.github.io/EnglishBook/" target="_blank">
             <img src="../assets/img/websitelink.png" class="gotoapp" style="padding: 7px 22px;"/>
           </a>


### PR DESCRIPTION
GitHub 리포지터리로 연결되는 모든 링크를 제거했습니다. 

2016, 2017년 대부분의 교육결과물 페이지의 GitHub 링크가 Mouda 페이지로 연결되어 있습니다. 